### PR TITLE
Update class names to remove clash

### DIFF
--- a/Switcher/switch.js
+++ b/Switcher/switch.js
@@ -6,7 +6,7 @@ angular.module('umbraco').directive('switch', function() {
     template: function(element, attrs) {
       var html = '';
       html += '<span';
-      html +=   ' class="switch' + (attrs.class ? ' ' + attrs.class : '') + '"';
+      html +=   ' class="switcher' + (attrs.class ? ' ' + attrs.class : '') + '"';
       html +=   attrs.ngModel ? ' ng-click="' + attrs.ngModel + '=!' + attrs.ngModel + '"' : '';
       html +=   ' ng-class="{ checked:' + attrs.ngModel + ' }"';
       html +=   '>';

--- a/Switcher/switcher.css
+++ b/Switcher/switcher.css
@@ -1,4 +1,4 @@
-.switch {
+.switcher{
   background: #fff;
   border: 1px solid #dfdfdf;
   position: relative;
@@ -16,7 +16,7 @@
   -webkit-transition: 0.3s ease-out all;
   top: -1px;
 }
-.switch small {
+.switcher small {
   background: #fff;
   border-radius: 100%;
   box-shadow: 0 1px 3px rgba(0,0,0,0.4);
@@ -28,11 +28,11 @@
   transition: 0.3s ease-out all;
   -webkit-transition: 0.3s ease-out all;
 }
-.switch.checked {
+.switcher.checked {
   background: rgb(100, 189, 99);
   border-color: rgb(100, 189, 99);
 }
-.switch.checked small {
+.switcher.checked small {
   left: 22px;
 }
 .switch-status {
@@ -47,11 +47,11 @@
   color: #343434;
 }
 
-.switch.blue.checked {
+.switcher.blue.checked {
   background: rgb(54, 180, 246);
   border-color: rgb(54, 180, 246);
 }
-.switch.red.checked {
+.switcher.red.checked {
   background: rgb(223, 59, 58);
   border-color: rgb(223, 59, 58);
 }


### PR DESCRIPTION
The .switch class is used by umbraco internally for the date time pickers
(i.e the controls on Publish As and unpublish at) - this causes the
datepicker classes to render a bit funny.

This change - renames the switch class to switcher to avoid the clash.
